### PR TITLE
Log out the error when reading bower.json fails

### DIFF
--- a/lib/preen.js
+++ b/lib/preen.js
@@ -14,7 +14,8 @@ function preen(options, callback) {
     bowerJSON = require(process.cwd()+'/'+bower.config.json);
   }
   catch(err) {
-    console.error('\u001b[31m'+'Did not find '+bower.config.json+'\u001b[0m');
+    console.error('\u001b[31m'+'Error trying to read '+bower.config.json+':\n\u001b[0m');
+    console.error('\t\u001b[31m'+err+'\u001b[0m');
     return;
   }
 


### PR DESCRIPTION
Also changed the wording in the error message to be more generic.

After a few minutes of trying to figure out why Preen couldn't find the 
bower.json file in the directory I was running it in, I put in the error 
logging and saw the problem was actually a a JSON formatting error in my 
bower.json file.
