### PR TITLE
Fix jquery minimatch glob in example.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ So I update my `bower.json` with a preen property as follows
   },
   "preen": {
     "jquery": [
-      "**.js"
+      "dist/*.js"
     ]
   }
 }


### PR DESCRIPTION
`**.js` strips all files, I think `**/*.js` was intended.  Even that though
includes all the src files, so I changed it to only include the dist
directory.
