### PR TITLE
Update preen.js

### DIFF
--- a/lib/preen.js
+++ b/lib/preen.js
@@ -71,7 +71,7 @@ var preenPackage = function(name, callback) {
 
         keepFilters = uniqueAdd(res.files[i].path, keepFilters);
 
-        var pDirs = res.files[i].parentDir.split('/');
+        var pDirs = res.files[i].parentDir.split(/[\/\\]/g);
         var pDir = '';
         var j, lengthJ;
         for (j = 0, lengthJ = pDirs.length; j < lengthJ; j += 1) {


### PR DESCRIPTION
changed pattern in split() to fix a bug on windows. Now works for both / and \ separators
