### PR TITLE
Added optional directory argument

### DIFF
--- a/lib/preen.js
+++ b/lib/preen.js
@@ -17,10 +17,14 @@ logger.cli();
 var bowerJSON;
 var preview = false; // an optional argument to show would happen when preen is run
 var verbose = false; // an optional argument to show details of the files/folders preened
+var directory; // an optional argument to set a custom root directory (for processing after copying bower files)
 
 function preen(options, callback) {
-	preview = options.preview;
+  
+  preview = options.preview;
   verbose = options.verbose;
+  directory = options.directory;
+
   if(preview || verbose){
     logger.transports.console.level = 'verbose';
   }
@@ -45,7 +49,7 @@ var preenPackage = function(name, callback) {
 
   logger.info(preview ? 'Previewing Preen of: '+name : 'Preening: '+name);
 
-  var root = bower.config.directory+'/'+name+'/';
+  var root = getRootDirectory()+'/'+name+'/';
   var filters = bowerJSON.preen[name];
 
   if(!filters.length){
@@ -56,7 +60,7 @@ var preenPackage = function(name, callback) {
   readdirp({ root: root, fileFilter: pathFilter(filters) },
     function (err, res) {
 
-    	if(!res) {
+      if(!res) {
         callback(err);
         return;
       }
@@ -124,8 +128,8 @@ var preenPackage = function(name, callback) {
 };
 
 /*function logger(output) {
-	if(!preview) return;
-	console.log(output);
+  if(!preview) return;
+  console.log(output);
 }*/
 
 function uniqueAdd(val, arr) {
@@ -231,4 +235,9 @@ function removeDir(path, callback) {
     logger.verbose('de', path, err);
     callback(err);
   });
+}
+
+function getRootDirectory() {
+
+  return directory || bower.config.directory
 }

--- a/readme.md
+++ b/readme.md
@@ -78,6 +78,8 @@ you can then run `preen` if you are happy to go ahead
 A verbose flag is also avaible to show the same level of detail as the actual preen is run
 `preen --verbose`
 
+You can also add a directory flag to override bower's default directory (or the one set in .bowerrc). This can be useful when using preen as part of your build pipeline. Example: `preen --directory ./tmp/path/to/bower/root`
+
 ##Grunt Task
 while preen can be run via the command line it is well suited to running as a [grunt task](https://github.com/braddenver/grunt-preen)
 [![NPM](https://nodei.co/npm/grunt-preen.png?downloads=true&stars=true)](https://github.com/braddenver/grunt-preen)


### PR DESCRIPTION
I'm using Preen with grunt as part of a build pipeline. I need to keep the bower_components directory intact, and copy the bower_components directory into a .tmp folder during the build process. When it's in the .tmp folder, I'd like to preen it.

I've added the "directory" option to support this. I've also updated the readme to show it's available.

This also works with [grunt-preen](https://github.com/BradDenver/grunt-preen) by adding it as an option in the config:

```javascript

options: {
	directory: '.tmp/public/bower/files'
}

```

If you want, I could a pull request to update grunt-preen's readme to reflect this change as well.