### PR TITLE
Add option 'cwd'

### DIFF
--- a/lib/preen.js
+++ b/lib/preen.js
@@ -1,6 +1,7 @@
 var async = require('async');
 var bower = require('bower');
 var fs = require('fs.extra');
+var path = require('path');
 var readdirp = require('readdirp');
 var minimatch = require('minimatch');
 var winston = require('winston');
@@ -18,19 +19,21 @@ var bowerJSON;
 var preview = false; // an optional argument to show would happen when preen is run
 var verbose = false; // an optional argument to show details of the files/folders preened
 var directory; // an optional argument to set a custom root directory (for processing after copying bower files)
+var cwd; // an optional argument to set a custom project directory
 
 function preen(options, callback) {
-  
+
   preview = options.preview;
   verbose = options.verbose;
   directory = options.directory;
+  cwd = options.cwd || process.cwd();
 
   if(preview || verbose){
     logger.transports.console.level = 'verbose';
   }
 
   try {
-    bowerJSON = require(process.cwd()+'/'+bower.config.json);
+    bowerJSON = require(path.join(cwd, bower.config.json));
   }
   catch(err) {
     logger.error('Error trying to read '+bower.config.json, err);
@@ -49,7 +52,7 @@ var preenPackage = function(name, callback) {
 
   logger.info(preview ? 'Previewing Preen of: '+name : 'Preening: '+name);
 
-  var root = getRootDirectory()+'/'+name+'/';
+  var root = path.join(getRootDirectory(), name);
   var filters = bowerJSON.preen[name];
 
   if(!filters.length){
@@ -98,7 +101,7 @@ var preenPackage = function(name, callback) {
               logger.verbose('keep dir ' + res.directories[i].path);
             } else {
               logger.verbose('delete dir ' + res.directories[i].path);
-              dirsToDelete.push(root+res.directories[i].path);
+              dirsToDelete.push(path.join(root, res.directories[i].path));
             }
           }
           // and then files
@@ -108,7 +111,7 @@ var preenPackage = function(name, callback) {
               logger.verbose('keep file ' + res.files[i].path);
             } else {
               logger.verbose('delete file ' + res.files[i].path);
-              filesToDelete.push(root+res.files[i].path);
+              filesToDelete.push(path.join(root, res.files[i].path));
             }
           }
 
@@ -239,5 +242,5 @@ function removeDir(path, callback) {
 
 function getRootDirectory() {
 
-  return directory || bower.config.directory
+  return path.join(cwd, (directory || bower.config.directory));
 }

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-#Preen
+#Preen [![Analytics](https://ga-beacon.appspot.com/UA-40041520-3/Preen/readme)](https://github.com/igrigorik/ga-beacon)
 
 >A Node.js module to preen unwanted files and folders from packages installed via Bower.
 
@@ -14,8 +14,8 @@ My projects `bower.json` file has jquery as a dependency.
   }
 }
 ```
-which gives the following folder after running `bower install`  
-![](https://raw.github.com/BradDenver/Preen/master/screenshots/basic.png)  
+which gives the following folder after running `bower install`
+![](https://raw.github.com/BradDenver/Preen/master/screenshots/basic.png)
 but all I really need for this project is the 4 javascript files.
 So I update my `bower.json` with a preen property as follows
 ```javascript
@@ -31,7 +31,7 @@ So I update my `bower.json` with a preen property as follows
   }
 }
 ```
-and then run `preen` to end up with  
+and then run `preen` to end up with
 ![](https://raw.github.com/BradDenver/Preen/master/screenshots/basic2.png)
 
 ###Updated Example
@@ -70,9 +70,9 @@ Any packages not listed will not be preened.
 
 ##Options
 when running via the command line you can add a preview flag to see a list of all paths and if they will be deleted or kept
-`preen --preview`  
-![](https://raw.github.com/BradDenver/Preen/master/screenshots/preview.png)  
-you can then run `preen` if you are happy to go ahead  
+`preen --preview`
+![](https://raw.github.com/BradDenver/Preen/master/screenshots/preview.png)
+you can then run `preen` if you are happy to go ahead
 ![](https://raw.github.com/BradDenver/Preen/master/screenshots/preview2.png)
 
 A verbose flag is also avaible to show the same level of detail as the actual preen is run

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-#Preen [![Analytics](https://ga-beacon.appspot.com/UA-40041520-3/Preen/readme)](https://github.com/igrigorik/ga-beacon)
+#Preen
 
 >A Node.js module to preen unwanted files and folders from packages installed via Bower.
 
@@ -79,6 +79,8 @@ A verbose flag is also avaible to show the same level of detail as the actual pr
 `preen --verbose`
 
 You can also add a directory flag to override bower's default directory (or the one set in .bowerrc). This can be useful when using preen as part of your build pipeline. Example: `preen --directory ./tmp/path/to/bower/root`
+
+Using `preen --cwd ./path/to/project` you can set another workung directory than the one where you started this script from. This is useful for automating tasks and run preen from a parent folder. (i.e. this option works similar to Bowers `cwd` option.)
 
 ##Grunt Task
 while preen can be run via the command line it is well suited to running as a [grunt task](https://github.com/braddenver/grunt-preen)


### PR DESCRIPTION
## Issue

Currently we can only execute Preen from the root of a Bower package, i.e. where a file named `.bowerrc` is present. In case this tool is run from outside the Bower repository (e.g. when incorporating into CI environments), it fails to find the Bower configuration.
## This pull request

Add an option 'cwd' to set the current working directory and execute Preen from e.g. a parent directory of the Bower project. This option now can be set to any Bower package and it doesn't matter anymore, from where Preen was executed.

I also decided to use `path.join` instead of string concatenation to avoid duplicate slashes in a a path (example as it occurred before: `path/to/project//bower_components/…`)
## Example

```
var preen = require( 'preen' );

preen.preen( {
    cwd: 'path/to/project/containing/.bowerrc'
} )
```
