### PR TITLE
remove version number from package.json (was 1.2.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "preen",
-  "version": "1.2.0",
   "homepage": "https://github.com/braddenver/preen",
   "description": "preen unwanted files in packages installed via Bower",
   "main": "./lib/preen.js",


### PR DESCRIPTION
## Issue

There are currently no github releases for Preen (see: https://github.com/BradDenver/Preen/releases). We should use git tags to denote each version and use default tools and features of github.com as well as [npm](https://github.com/npm/npm)
## This pull request

I removed the version number from the package.json. The package.json version number is not required by npm – it also uses git tags happily. That way one don't need to mention the version twice – as strign inside a JSON file a as git tag.

Afterwards I added a git version tag for my changes; see: https://github.com/votum/Preen/releases
## Example

```
git tag v1.3.0
git push origin v1.3.0
```
